### PR TITLE
Implement roles and courses

### DIFF
--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum UserRole: string
+{
+    case ADMIN = 'admin';
+    case MODERATOR = 'moderator';
+    case AUTHOR = 'author';
+    case STUDENT = 'student';
+}

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Course;
+use App\Enums\UserRole;
+
+class CourseController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $user = $request->user();
+
+        if (in_array($user->role, [UserRole::ADMIN, UserRole::MODERATOR])) {
+            $courses = Course::all();
+        } elseif ($user->role === UserRole::AUTHOR) {
+            $courses = Course::where('user_id', $user->id)->get();
+        } else {
+            $courses = Course::all();
+        }
+
+        return response()->json($courses);
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create(Request $request)
+    {
+        $user = $request->user();
+        if (! in_array($user->role, [UserRole::ADMIN, UserRole::AUTHOR])) {
+            abort(403);
+        }
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $user = $request->user();
+        if (! in_array($user->role, [UserRole::ADMIN, UserRole::AUTHOR])) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'title' => 'required|string',
+            'description' => 'nullable|string',
+            'image' => 'nullable|string',
+            'price' => 'required|numeric',
+        ]);
+
+        $course = Course::create(array_merge($validated, ['user_id' => $user->id]));
+
+        return response()->json($course, 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        $course = Course::findOrFail($id);
+        return response()->json($course);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        $course = Course::findOrFail($id);
+        $user = request()->user();
+
+        if ($user->role === UserRole::ADMIN ||
+            $user->role === UserRole::MODERATOR ||
+            ($user->role === UserRole::AUTHOR && $course->user_id == $user->id)) {
+            return response()->json($course);
+        }
+
+        abort(403);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        $course = Course::findOrFail($id);
+        $user = $request->user();
+
+        if (! ($user->role === UserRole::ADMIN ||
+            $user->role === UserRole::MODERATOR ||
+            ($user->role === UserRole::AUTHOR && $course->user_id == $user->id))) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'title' => 'sometimes|required|string',
+            'description' => 'nullable|string',
+            'image' => 'nullable|string',
+            'price' => 'sometimes|required|numeric',
+        ]);
+
+        $course->update($validated);
+
+        return response()->json($course);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        $course = Course::findOrFail($id);
+        $user = request()->user();
+
+        if (! ($user->role === UserRole::ADMIN ||
+            ($user->role === UserRole::AUTHOR && $course->user_id == $user->id))) {
+            abort(403);
+        }
+
+        $course->delete();
+
+        return response()->json(['status' => 'deleted']);
+    }
+}

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use BackedEnum;
+
+class RoleMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, ...$roles): Response
+    {
+        $user = $request->user();
+
+        if (! $user || ! in_array($user->role instanceof \BackedEnum ? $user->role->value : $user->role, $roles)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\User;
+
+class Course extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+        'description',
+        'image',
+        'price',
+    ];
+
+    public function author()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Enums\UserRole;
 
 class User extends Authenticatable
 {
@@ -21,6 +22,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**
@@ -43,6 +45,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'role' => UserRole::class,
         ];
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,7 +16,9 @@ return Application::configure(basePath: dirname(__DIR__))
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
         ]);
 
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\RoleMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/database/factories/CourseFactory.php
+++ b/database/factories/CourseFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Course>
+ */
+class CourseFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => \App\Models\User::factory(),
+            'title' => fake()->sentence(3),
+            'description' => fake()->paragraph(),
+            'image' => fake()->imageUrl(),
+            'price' => fake()->randomFloat(2, 10, 100),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
+use App\Enums\UserRole;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
@@ -28,6 +29,7 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'role' => \App\Enums\UserRole::STUDENT,
             'remember_token' => Str::random(10),
         ];
     }

--- a/database/migrations/2025_07_17_050901_create_courses_table.php
+++ b/database/migrations/2025_07_17_050901_create_courses_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('courses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('image')->nullable();
+            $table->decimal('price', 8, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('courses');
+    }
+};

--- a/database/migrations/2025_07_17_050903_add_role_to_users_table.php
+++ b/database/migrations/2025_07_17_050903_add_role_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('student');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\CourseController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -22,6 +23,20 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::get('/courses', [CourseController::class, 'index'])->name('courses.index');
+    Route::get('/courses/{course}', [CourseController::class, 'show'])->name('courses.show');
+
+    Route::middleware('role:admin,author')->group(function () {
+        Route::get('/courses/create', [CourseController::class, 'create'])->name('courses.create');
+        Route::post('/courses', [CourseController::class, 'store'])->name('courses.store');
+        Route::delete('/courses/{course}', [CourseController::class, 'destroy'])->name('courses.destroy');
+    });
+
+    Route::middleware('role:admin,moderator,author')->group(function () {
+        Route::get('/courses/{course}/edit', [CourseController::class, 'edit'])->name('courses.edit');
+        Route::put('/courses/{course}', [CourseController::class, 'update'])->name('courses.update');
+    });
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add role column for users and create UserRole enum
- create Course model with controller, middleware and factory
- add migrations to persist courses and user roles
- register role middleware and build course routes
- update factories and bootstrap app

## Testing
- `php artisan migrate --seed --force`
- `npm install`
- `npm run build`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68788531a1b4832898b48930a4f326bf