### PR TITLE
Add course management for authors and admins

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -8,6 +8,7 @@ use App\Models\Module;
 use App\Models\Lesson;
 use Illuminate\Support\Arr;
 use App\Enums\UserRole;
+use Inertia\Inertia;
 
 class CourseController extends Controller
 {
@@ -27,6 +28,26 @@ class CourseController extends Controller
         }
 
         return response()->json($courses);
+    }
+
+    public function manage(Request $request)
+    {
+        $user = $request->user();
+
+        if (! in_array($user->role, [UserRole::ADMIN, UserRole::AUTHOR])) {
+            abort(403);
+        }
+
+        $query = Course::with('modules.lessons');
+        if ($user->role === UserRole::AUTHOR) {
+            $query->where('user_id', $user->id);
+        }
+
+        $courses = $query->get();
+
+        return Inertia::render('Courses/Index', [
+            'courses' => $courses,
+        ]);
     }
 
     /**

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -39,6 +39,13 @@ const showingNavigationDropdown = ref(false);
                                 >
                                     Dashboard
                                 </NavLink>
+                                <NavLink
+                                    v-if="['admin','author'].includes($page.props.auth.user.role)"
+                                    :href="route('courses.manage')"
+                                    :active="route().current('courses.manage')"
+                                >
+                                    My Courses
+                                </NavLink>
                             </div>
                         </div>
 
@@ -145,6 +152,13 @@ const showingNavigationDropdown = ref(false);
                             :active="route().current('dashboard')"
                         >
                             Dashboard
+                        </ResponsiveNavLink>
+                        <ResponsiveNavLink
+                            v-if="['admin','author'].includes($page.props.auth.user.role)"
+                            :href="route('courses.manage')"
+                            :active="route().current('courses.manage')"
+                        >
+                            My Courses
                         </ResponsiveNavLink>
                     </div>
 

--- a/resources/js/Pages/Courses/Index.vue
+++ b/resources/js/Pages/Courses/Index.vue
@@ -1,0 +1,99 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, useForm } from '@inertiajs/vue3';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import InputError from '@/Components/InputError.vue';
+
+const props = defineProps({
+    courses: Array,
+});
+
+const form = useForm({
+    title: '',
+    modules: [],
+});
+
+function addModule() {
+    form.modules.push({ title: '', lessons: [] });
+}
+
+function addLesson(module) {
+    module.lessons.push({ title: '' });
+}
+
+function submit() {
+    form.post(route('courses.store'), {
+        preserveScroll: true,
+        onSuccess: () => form.reset(),
+    });
+}
+</script>
+
+<template>
+    <Head title="My Courses" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                My Courses
+            </h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <div class="overflow-hidden bg-white p-6 shadow-sm sm:rounded-lg">
+                    <div v-if="courses.length === 0" class="mb-4 text-gray-600">
+                        No courses yet.
+                    </div>
+                    <div v-else class="mb-6">
+                        <div v-for="course in courses" :key="course.id" class="mb-4">
+                            <div class="font-bold">{{ course.title }}</div>
+                            <ul class="ml-4 list-disc">
+                                <li v-for="module in course.modules" :key="module.id">
+                                    {{ module.title }}
+                                    <ul class="ml-4 list-disc">
+                                        <li v-for="lesson in module.lessons" :key="lesson.id">
+                                            {{ lesson.title }}
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <form @submit.prevent="submit">
+                        <h3 class="mb-2 font-semibold">Create Course</h3>
+                        <div class="mb-4">
+                            <InputLabel value="Course Title" />
+                            <TextInput v-model="form.title" class="mt-1 block w-full" />
+                            <InputError :message="form.errors.title" class="mt-2" />
+                        </div>
+                        <div v-for="(module, mIndex) in form.modules" :key="mIndex" class="mb-4 border p-2">
+                            <InputLabel value="Module Title" />
+                            <TextInput v-model="module.title" class="mt-1 block w-full" />
+                            <InputError :message="form.errors[`modules.${mIndex}.title`]" class="mt-2" />
+                            <div class="ml-4 mt-2" v-for="(lesson, lIndex) in module.lessons" :key="lIndex">
+                                <InputLabel value="Lesson Title" />
+                                <TextInput v-model="lesson.title" class="mt-1 block w-full" />
+                                <InputError :message="form.errors[`modules.${mIndex}.lessons.${lIndex}.title`]" class="mt-2" />
+                            </div>
+                            <PrimaryButton type="button" class="mt-2" @click="addLesson(module)">
+                                Add Lesson
+                            </PrimaryButton>
+                        </div>
+                        <PrimaryButton type="button" class="mb-4" @click="addModule">
+                            Add Module
+                        </PrimaryButton>
+                        <div>
+                            <PrimaryButton :disabled="form.processing">
+                                Save
+                            </PrimaryButton>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/courses/{course}', [CourseController::class, 'show'])->name('courses.show');
 
     Route::middleware('role:admin,author')->group(function () {
+        Route::get('/cabinet', [CourseController::class, 'manage'])->name('courses.manage');
         Route::get('/courses/create', [CourseController::class, 'create'])->name('courses.create');
         Route::post('/courses', [CourseController::class, 'store'])->name('courses.store');
         Route::delete('/courses/{course}', [CourseController::class, 'destroy'])->name('courses.destroy');


### PR DESCRIPTION
## Summary
- add `/cabinet` route to manage courses
- update `CourseController` with `manage` action returning Inertia page
- add *My Courses* navigation links
- create `resources/js/Pages/Courses/Index.vue` with form to create courses with modules and lessons

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6878c23ea87883289aea1f7ab41fecc3