### PR TITLE
Restrict dashboard access to admins

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,7 @@ Route::get('/', function () {
 
 Route::get('/dashboard', function () {
     return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+})->middleware(['auth', 'verified', 'role:admin'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/tests/Feature/AuthorDashboardTest.php
+++ b/tests/Feature/AuthorDashboardTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Enums\UserRole;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuthorDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_author_cannot_access_dashboard(): void
+    {
+        $user = User::factory()->create(['role' => UserRole::AUTHOR]);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertForbidden();
+    }
+
+    public function test_author_can_access_cabinet(): void
+    {
+        $user = User::factory()->create(['role' => UserRole::AUTHOR]);
+
+        $response = $this->actingAs($user)->get('/cabinet');
+
+        $response->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary
- restrict `/dashboard` to the `admin` role
- test that authors are forbidden from `/dashboard` but can still access `/cabinet`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6878c84e1cd0832883d9cf5aad1e60bd