### PR TITLE
Add dedicated course creation page

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -60,7 +60,7 @@ class CourseController extends Controller
             abort(403);
         }
 
-        return response()->json(['status' => 'ok']);
+        return Inertia::render('Courses/Create');
     }
 
     /**

--- a/resources/js/Pages/Courses/Create.vue
+++ b/resources/js/Pages/Courses/Create.vue
@@ -1,0 +1,75 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, useForm } from '@inertiajs/vue3';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import InputError from '@/Components/InputError.vue';
+
+const form = useForm({
+    title: '',
+    modules: [],
+});
+
+function addModule() {
+    form.modules.push({ title: '', lessons: [] });
+}
+
+function addLesson(module) {
+    module.lessons.push({ title: '' });
+}
+
+function submit() {
+    form.post(route('courses.store'), {
+        preserveScroll: true,
+        onSuccess: () => form.reset(),
+    });
+}
+</script>
+
+<template>
+    <Head title="Create Course" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                Create Course
+            </h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <div class="overflow-hidden bg-white p-6 shadow-sm sm:rounded-lg">
+                    <form @submit.prevent="submit">
+                        <div class="mb-4">
+                            <InputLabel value="Course Title" />
+                            <TextInput v-model="form.title" class="mt-1 block w-full" />
+                            <InputError :message="form.errors.title" class="mt-2" />
+                        </div>
+                        <div v-for="(module, mIndex) in form.modules" :key="mIndex" class="mb-4 border p-2">
+                            <InputLabel value="Module Title" />
+                            <TextInput v-model="module.title" class="mt-1 block w-full" />
+                            <InputError :message="form.errors[`modules.${mIndex}.title`]" class="mt-2" />
+                            <div class="ml-4 mt-2" v-for="(lesson, lIndex) in module.lessons" :key="lIndex">
+                                <InputLabel value="Lesson Title" />
+                                <TextInput v-model="lesson.title" class="mt-1 block w-full" />
+                                <InputError :message="form.errors[`modules.${mIndex}.lessons.${lIndex}.title`]" class="mt-2" />
+                            </div>
+                            <PrimaryButton type="button" class="mt-2" @click="addLesson(module)">
+                                Add Lesson
+                            </PrimaryButton>
+                        </div>
+                        <PrimaryButton type="button" class="mb-4" @click="addModule">
+                            Add Module
+                        </PrimaryButton>
+                        <div>
+                            <PrimaryButton :disabled="form.processing">
+                                Save
+                            </PrimaryButton>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Courses/Index.vue
+++ b/resources/js/Pages/Courses/Index.vue
@@ -1,34 +1,11 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
-import { Head, useForm } from '@inertiajs/vue3';
-import PrimaryButton from '@/Components/PrimaryButton.vue';
-import TextInput from '@/Components/TextInput.vue';
-import InputLabel from '@/Components/InputLabel.vue';
-import InputError from '@/Components/InputError.vue';
+import { Head, Link } from '@inertiajs/vue3';
 
 const props = defineProps({
     courses: Array,
 });
 
-const form = useForm({
-    title: '',
-    modules: [],
-});
-
-function addModule() {
-    form.modules.push({ title: '', lessons: [] });
-}
-
-function addLesson(module) {
-    module.lessons.push({ title: '' });
-}
-
-function submit() {
-    form.post(route('courses.store'), {
-        preserveScroll: true,
-        onSuccess: () => form.reset(),
-    });
-}
 </script>
 
 <template>
@@ -63,35 +40,14 @@ function submit() {
                         </div>
                     </div>
 
-                    <form @submit.prevent="submit">
-                        <h3 class="mb-2 font-semibold">Create Course</h3>
-                        <div class="mb-4">
-                            <InputLabel value="Course Title" />
-                            <TextInput v-model="form.title" class="mt-1 block w-full" />
-                            <InputError :message="form.errors.title" class="mt-2" />
-                        </div>
-                        <div v-for="(module, mIndex) in form.modules" :key="mIndex" class="mb-4 border p-2">
-                            <InputLabel value="Module Title" />
-                            <TextInput v-model="module.title" class="mt-1 block w-full" />
-                            <InputError :message="form.errors[`modules.${mIndex}.title`]" class="mt-2" />
-                            <div class="ml-4 mt-2" v-for="(lesson, lIndex) in module.lessons" :key="lIndex">
-                                <InputLabel value="Lesson Title" />
-                                <TextInput v-model="lesson.title" class="mt-1 block w-full" />
-                                <InputError :message="form.errors[`modules.${mIndex}.lessons.${lIndex}.title`]" class="mt-2" />
-                            </div>
-                            <PrimaryButton type="button" class="mt-2" @click="addLesson(module)">
-                                Add Lesson
-                            </PrimaryButton>
-                        </div>
-                        <PrimaryButton type="button" class="mb-4" @click="addModule">
-                            Add Module
-                        </PrimaryButton>
-                        <div>
-                            <PrimaryButton :disabled="form.processing">
-                                Save
-                            </PrimaryButton>
-                        </div>
-                    </form>
+                    <div class="mt-4">
+                        <Link
+                            :href="route('courses.create')"
+                            class="text-sm text-blue-600 underline hover:text-blue-800"
+                        >
+                            Create New Course
+                        </Link>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- create a dedicated `Courses/Create` page for authors and admins
- render the new page from `CourseController::create`
- simplify `Courses/Index` to just list courses and link to the create page

## Testing
- `composer install`
- `php artisan key:generate`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6878cd85dec88328b6b95796b2afb05a