### PR TITLE
Fix course create page route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,6 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
     Route::get('/courses', [CourseController::class, 'index'])->name('courses.index');
-    Route::get('/courses/{course}', [CourseController::class, 'show'])->name('courses.show');
 
     Route::middleware('role:admin,author')->group(function () {
         Route::get('/cabinet', [CourseController::class, 'manage'])->name('courses.manage');
@@ -38,6 +37,8 @@ Route::middleware('auth')->group(function () {
         Route::get('/courses/{course}/edit', [CourseController::class, 'edit'])->name('courses.edit');
         Route::put('/courses/{course}', [CourseController::class, 'update'])->name('courses.update');
     });
+
+    Route::get('/courses/{course}', [CourseController::class, 'show'])->name('courses.show');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- fix `/courses/create` being captured by dynamic route by placing show route after admin routes

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6878d139ce648328ac69a9a83f9e9ccd