### PR TITLE
Add course views with module and lesson details

### DIFF
--- a/app/Models/Lesson.php
+++ b/app/Models/Lesson.php
@@ -13,6 +13,9 @@ class Lesson extends Model
     protected $fillable = [
         'module_id',
         'title',
+        'description',
+        'video_url',
+        'pdf_path',
     ];
 
     public function module()

--- a/app/Models/Module.php
+++ b/app/Models/Module.php
@@ -14,6 +14,7 @@ class Module extends Model
     protected $fillable = [
         'course_id',
         'title',
+        'description',
     ];
 
     public function course()

--- a/database/migrations/2025_07_17_110603_add_details_to_modules_and_lessons.php
+++ b/database/migrations/2025_07_17_110603_add_details_to_modules_and_lessons.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('modules', function (Blueprint $table) {
+            $table->text('description')->nullable();
+        });
+
+        Schema::table('lessons', function (Blueprint $table) {
+            $table->text('description')->nullable();
+            $table->string('video_url')->nullable();
+            $table->string('pdf_path')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('modules', function (Blueprint $table) {
+            $table->dropColumn('description');
+        });
+
+        Schema::table('lessons', function (Blueprint $table) {
+            $table->dropColumn(['description', 'video_url', 'pdf_path']);
+        });
+    }
+};

--- a/resources/js/Pages/Courses/Create.vue
+++ b/resources/js/Pages/Courses/Create.vue
@@ -13,16 +13,17 @@ const form = useForm({
 });
 
 function addModule() {
-    form.modules.push({ title: '', lessons: [] });
+    form.modules.push({ title: '', description: '', lessons: [] });
 }
 
 function addLesson(module) {
-    module.lessons.push({ title: '' });
+    module.lessons.push({ title: '', description: '', video_url: '', pdf: null });
 }
 
 function submit() {
     form.post(route('courses.store'), {
         preserveScroll: true,
+        forceFormData: true,
         onSuccess: () => form.reset(),
     });
 }
@@ -56,10 +57,22 @@ function submit() {
                             <InputLabel value="Module Title" />
                             <TextInput v-model="module.title" class="mt-1 block w-full" />
                             <InputError :message="form.errors[`modules.${mIndex}.title`]" class="mt-2" />
+                            <InputLabel value="Module Description" class="mt-2" />
+                            <textarea v-model="module.description" class="mt-1 block w-full rounded-md border-gray-300"></textarea>
+                            <InputError :message="form.errors[`modules.${mIndex}.description`]" class="mt-2" />
                             <div class="ml-4 mt-2" v-for="(lesson, lIndex) in module.lessons" :key="lIndex">
                                 <InputLabel value="Lesson Title" />
                                 <TextInput v-model="lesson.title" class="mt-1 block w-full" />
                                 <InputError :message="form.errors[`modules.${mIndex}.lessons.${lIndex}.title`]" class="mt-2" />
+                                <InputLabel value="Lesson Description" class="mt-2" />
+                                <textarea v-model="lesson.description" class="mt-1 block w-full rounded-md border-gray-300"></textarea>
+                                <InputError :message="form.errors[`modules.${mIndex}.lessons.${lIndex}.description`]" class="mt-2" />
+                                <InputLabel value="Video URL" class="mt-2" />
+                                <TextInput v-model="lesson.video_url" class="mt-1 block w-full" />
+                                <InputError :message="form.errors[`modules.${mIndex}.lessons.${lIndex}.video_url`]" class="mt-2" />
+                                <InputLabel value="PDF" class="mt-2" />
+                                <input type="file" accept="application/pdf" @change="e => lesson.pdf = e.target.files[0]" class="mt-1 block w-full" />
+                                <InputError :message="form.errors[`modules.${mIndex}.lessons.${lIndex}.pdf`]" class="mt-2" />
                             </div>
                             <PrimaryButton type="button" class="mt-2" @click="addLesson(module)">
                                 Add Lesson

--- a/resources/js/Pages/Courses/Index.vue
+++ b/resources/js/Pages/Courses/Index.vue
@@ -26,7 +26,9 @@ const props = defineProps({
                     </div>
                     <div v-else class="mb-6">
                         <div v-for="course in courses" :key="course.id" class="mb-4">
-                            <div class="font-bold">{{ course.title }}</div>
+                            <Link :href="route('courses.show', course.id)" class="font-bold text-blue-600 underline">
+                                {{ course.title }}
+                            </Link>
                             <ul class="ml-4 list-disc">
                                 <li v-for="module in course.modules" :key="module.id">
                                     {{ module.title }}

--- a/resources/js/Pages/Courses/PublicIndex.vue
+++ b/resources/js/Pages/Courses/PublicIndex.vue
@@ -1,0 +1,37 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+
+const props = defineProps({
+    courses: Array,
+});
+</script>
+
+<template>
+    <Head title="Courses" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                Courses
+            </h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <div class="overflow-hidden bg-white p-6 shadow-sm sm:rounded-lg">
+                    <div v-if="courses.length === 0" class="text-gray-600">
+                        No courses available.
+                    </div>
+                    <ul v-else class="list-disc pl-5">
+                        <li v-for="course in courses" :key="course.id" class="mb-2">
+                            <Link :href="route('courses.show', course.id)" class="text-blue-600 underline">
+                                {{ course.title }}
+                            </Link>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Courses/Show.vue
+++ b/resources/js/Pages/Courses/Show.vue
@@ -1,0 +1,45 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head } from '@inertiajs/vue3';
+
+const props = defineProps({
+    course: Object,
+});
+</script>
+
+<template>
+    <Head :title="course.title" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                {{ course.title }}
+            </h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <div class="overflow-hidden bg-white p-6 shadow-sm sm:rounded-lg">
+                    <p class="mb-6" v-if="course.description">{{ course.description }}</p>
+
+                    <div v-for="module in course.modules" :key="module.id" class="mb-6">
+                        <h3 class="text-lg font-bold">{{ module.title }}</h3>
+                        <p class="mb-2 text-gray-600" v-if="module.description">{{ module.description }}</p>
+                        <ul class="ml-4 list-disc">
+                            <li v-for="lesson in module.lessons" :key="lesson.id" class="mb-3">
+                                <div class="font-medium">{{ lesson.title }}</div>
+                                <p class="text-sm text-gray-600" v-if="lesson.description">{{ lesson.description }}</p>
+                                <div v-if="lesson.video_url" class="mt-1">
+                                    <a :href="lesson.video_url" target="_blank" class="text-blue-600 underline">Watch video</a>
+                                </div>
+                                <div v-if="lesson.pdf_path" class="mt-1">
+                                    <a :href="lesson.pdf_path" target="_blank" class="text-blue-600 underline">Download PDF</a>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>


### PR DESCRIPTION
## Summary
- show course list and details via Inertia
- extend modules and lessons with description fields
- allow lessons to store video URLs and PDFs
- support file uploads in course form
- database migration for new columns

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6878d86aad64832881853cba66966a61