### PR TITLE
Display video player in course view

### DIFF
--- a/resources/js/Components/VideoPlayer.vue
+++ b/resources/js/Components/VideoPlayer.vue
@@ -1,0 +1,43 @@
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+    src: {
+        type: String,
+        required: true
+    }
+});
+
+const embedUrl = computed(() => {
+    if (!props.src) return '';
+    const ytMatch = props.src.match(/(?:youtube\.com.*[?&]v=|youtu\.be\/)([\w-]+)/i);
+    if (ytMatch) {
+        return `https://www.youtube.com/embed/${ytMatch[1]}`;
+    }
+    const vimeoMatch = props.src.match(/vimeo\.com\/(\d+)/i);
+    if (vimeoMatch) {
+        return `https://player.vimeo.com/video/${vimeoMatch[1]}`;
+    }
+    return props.src;
+});
+</script>
+
+<template>
+    <div class="aspect-video w-full">
+        <iframe
+            v-if="embedUrl !== src"
+            :src="embedUrl"
+            frameborder="0"
+            allowfullscreen
+            class="h-full w-full rounded"
+        />
+        <video
+            v-else
+            controls
+            class="h-full w-full rounded"
+        >
+            <source :src="src" />
+            Your browser does not support the video tag.
+        </video>
+    </div>
+</template>

--- a/resources/js/Pages/Courses/Show.vue
+++ b/resources/js/Pages/Courses/Show.vue
@@ -1,6 +1,7 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head } from '@inertiajs/vue3';
+import VideoPlayer from '@/Components/VideoPlayer.vue';
 
 const props = defineProps({
     course: Object,
@@ -29,8 +30,8 @@ const props = defineProps({
                             <li v-for="lesson in module.lessons" :key="lesson.id" class="mb-3">
                                 <div class="font-medium">{{ lesson.title }}</div>
                                 <p class="text-sm text-gray-600" v-if="lesson.description">{{ lesson.description }}</p>
-                                <div v-if="lesson.video_url" class="mt-1">
-                                    <a :href="lesson.video_url" target="_blank" class="text-blue-600 underline">Watch video</a>
+                                <div v-if="lesson.video_url" class="mt-3">
+                                    <VideoPlayer :src="lesson.video_url" />
                                 </div>
                                 <div v-if="lesson.pdf_path" class="mt-1">
                                     <a :href="lesson.pdf_path" target="_blank" class="text-blue-600 underline">Download PDF</a>


### PR DESCRIPTION
## Summary
- show video players in course lessons instead of plain links
- add generic `VideoPlayer` component to handle YouTube, Vimeo and direct links

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6878dbe354808328a01189b2eaf28a8f