### PR TITLE
Add student course pages and enrollment management

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -124,7 +124,18 @@ class CourseController extends Controller
      */
     public function show(string $id)
     {
-        $course = Course::with('modules.lessons')->findOrFail($id);
+        $course = Course::with(['modules.lessons', 'students'])->findOrFail($id);
+        $user = request()->user();
+
+        $allowed = $user->role === UserRole::ADMIN
+            || $user->role === UserRole::MODERATOR
+            || ($user->role === UserRole::AUTHOR && $course->user_id == $user->id)
+            || $course->students->contains($user->id);
+
+        if (! $allowed) {
+            abort(403);
+        }
+
         return Inertia::render('Courses/Show', [
             'course' => $course,
         ]);

--- a/app/Http/Controllers/CourseEnrollmentController.php
+++ b/app/Http/Controllers/CourseEnrollmentController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Course;
+use App\Models\User;
+use Illuminate\Support\Facades\Redirect;
+use Inertia\Inertia;
+
+class CourseEnrollmentController extends Controller
+{
+    public function index(Request $request, Course $course)
+    {
+        $user = $request->user();
+
+        if ($user->role !== \App\Enums\UserRole::ADMIN && $user->id !== $course->user_id) {
+            abort(403);
+        }
+
+        return Inertia::render('Courses/Students', [
+            'course' => $course->load('students'),
+        ]);
+    }
+
+    public function store(Request $request, Course $course)
+    {
+        $user = $request->user();
+
+        if ($user->role !== \App\Enums\UserRole::ADMIN && $user->id !== $course->user_id) {
+            abort(403);
+        }
+
+        $data = $request->validate([
+            'identifier' => 'required',
+        ]);
+
+        $student = User::where('id', $data['identifier'])
+            ->orWhere('name', $data['identifier'])->firstOrFail();
+
+        $course->students()->syncWithoutDetaching([$student->id]);
+
+        return Redirect::back();
+    }
+
+    public function destroy(Request $request, Course $course, User $user)
+    {
+        $auth = $request->user();
+
+        if ($auth->role !== \App\Enums\UserRole::ADMIN && $auth->id !== $course->user_id) {
+            abort(403);
+        }
+
+        $course->students()->detach($user->id);
+
+        return Redirect::back();
+    }
+}

--- a/app/Http/Controllers/StudentCourseController.php
+++ b/app/Http/Controllers/StudentCourseController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class StudentCourseController extends Controller
+{
+    public function index(Request $request)
+    {
+        $courses = $request->user()->courses()->with('modules.lessons')->get();
+
+        return Inertia::render('Courses/Enrolled', [
+            'courses' => $courses,
+        ]);
+    }
+}

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -28,4 +28,9 @@ class Course extends Model
     {
         return $this->hasMany(Module::class);
     }
+
+    public function students()
+    {
+        return $this->belongsToMany(User::class)->withTimestamps();
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use App\Enums\UserRole;
+use App\Models\Course;
 
 class User extends Authenticatable
 {
@@ -47,5 +48,15 @@ class User extends Authenticatable
             'password' => 'hashed',
             'role' => UserRole::class,
         ];
+    }
+
+    public function courses()
+    {
+        return $this->belongsToMany(Course::class)->withTimestamps();
+    }
+
+    public function authoredCourses()
+    {
+        return $this->hasMany(Course::class);
     }
 }

--- a/database/migrations/2025_07_20_042659_create_course_user_table.php
+++ b/database/migrations/2025_07_20_042659_create_course_user_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('course_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['course_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('course_user');
+    }
+};

--- a/resources/js/Pages/Courses/Enrolled.vue
+++ b/resources/js/Pages/Courses/Enrolled.vue
@@ -1,0 +1,49 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+
+const props = defineProps({
+    courses: Array,
+});
+
+</script>
+
+<template>
+    <Head title="Enrolled Courses" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                Enrolled Courses
+            </h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <div class="overflow-hidden bg-white p-6 shadow-sm sm:rounded-lg">
+                    <div v-if="courses.length === 0" class="mb-4 text-gray-600">
+                        No courses yet.
+                    </div>
+                    <div v-else class="mb-6">
+                        <div v-for="course in courses" :key="course.id" class="mb-4">
+                            <Link :href="route('courses.show', course.id)" class="font-bold text-blue-600 underline">
+                                {{ course.title }}
+                            </Link>
+                            <ul class="ml-4 list-disc">
+                                <li v-for="module in course.modules" :key="module.id">
+                                    {{ module.title }}
+                                    <ul class="ml-4 list-disc">
+                                        <li v-for="lesson in module.lessons" :key="lesson.id">
+                                            {{ lesson.title }}
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Courses/Students.vue
+++ b/resources/js/Pages/Courses/Students.vue
@@ -1,0 +1,53 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+const props = defineProps({
+    course: Object,
+});
+
+const form = useForm({
+    identifier: '',
+});
+
+function addStudent() {
+    form.post(route('courses.students.store', props.course.id), {
+        preserveScroll: true,
+        onSuccess: () => form.reset(),
+    });
+}
+</script>
+
+<template>
+    <Head :title="course.title" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">
+                Students for {{ course.title }}
+            </h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <div class="overflow-hidden bg-white p-6 shadow-sm sm:rounded-lg">
+                    <form @submit.prevent="addStudent" class="mb-4 flex space-x-2">
+                        <input v-model="form.identifier" class="rounded border-gray-300" placeholder="ID or Name" />
+                        <button type="submit" class="rounded bg-blue-600 px-3 py-1 text-white">Add</button>
+                    </form>
+
+                    <ul class="list-disc pl-5" v-if="course.students.length">
+                        <li v-for="student in course.students" :key="student.id" class="mb-1 flex items-center justify-between">
+                            <span>{{ student.name }} ({{ student.id }})</span>
+                            <form :action="route('courses.students.destroy', [course.id, student.id])" method="post">
+                                <input type="hidden" name="_method" value="delete" />
+                                <button type="submit" class="text-red-600 underline">Remove</button>
+                            </form>
+                        </li>
+                    </ul>
+                    <div v-else class="text-gray-600">No students enrolled.</div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,8 @@
 
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\CourseController;
+use App\Http\Controllers\StudentCourseController;
+use App\Http\Controllers\CourseEnrollmentController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -26,11 +28,17 @@ Route::middleware('auth')->group(function () {
 
     Route::get('/courses', [CourseController::class, 'index'])->name('courses.index');
 
+    Route::get('/my-courses', [StudentCourseController::class, 'index'])->name('student.courses.index');
+
     Route::middleware('role:admin,author')->group(function () {
         Route::get('/cabinet', [CourseController::class, 'manage'])->name('courses.manage');
         Route::get('/courses/create', [CourseController::class, 'create'])->name('courses.create');
         Route::post('/courses', [CourseController::class, 'store'])->name('courses.store');
         Route::delete('/courses/{course}', [CourseController::class, 'destroy'])->name('courses.destroy');
+
+        Route::get('/courses/{course}/students', [CourseEnrollmentController::class, 'index'])->name('courses.students.index');
+        Route::post('/courses/{course}/students', [CourseEnrollmentController::class, 'store'])->name('courses.students.store');
+        Route::delete('/courses/{course}/students/{user}', [CourseEnrollmentController::class, 'destroy'])->name('courses.students.destroy');
     });
 
     Route::middleware('role:admin,moderator,author')->group(function () {

--- a/tests/Feature/CourseEnrollmentTest.php
+++ b/tests/Feature/CourseEnrollmentTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Course;
+use App\Enums\UserRole;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CourseEnrollmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_author_can_enroll_and_remove_student(): void
+    {
+        $author = User::factory()->create(['role' => UserRole::AUTHOR]);
+        $student = User::factory()->create();
+        $course = Course::factory()->create(['user_id' => $author->id]);
+
+        $response = $this->actingAs($author)->post("/courses/{$course->id}/students", [
+            'identifier' => $student->id,
+        ]);
+        $response->assertStatus(302);
+        $this->assertDatabaseHas('course_user', [
+            'course_id' => $course->id,
+            'user_id' => $student->id,
+        ]);
+
+        $response = $this->actingAs($author)->delete("/courses/{$course->id}/students/{$student->id}");
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('course_user', [
+            'course_id' => $course->id,
+            'user_id' => $student->id,
+        ]);
+    }
+}

--- a/tests/Feature/StudentCourseTest.php
+++ b/tests/Feature/StudentCourseTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Course;
+use App\Enums\UserRole;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentCourseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_student_can_view_enrolled_courses(): void
+    {
+        $student = User::factory()->create();
+        $course = Course::factory()->create();
+        $course->students()->attach($student);
+
+        $response = $this->actingAs($student)->get('/my-courses');
+
+        $response->assertOk();
+        $response->assertSee($course->title);
+    }
+}


### PR DESCRIPTION
## Summary
- add pivot table for course enrollments
- allow students to view their enrolled courses
- allow authors to manage course enrollments
- restrict viewing courses unless enrolled or author/admin
- add Vue pages for enrolled courses and student lists
- cover new features with tests

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_687c6fc0ed2c8328a677254563208c4c