### PR TITLE
Add author student management

### DIFF
--- a/app/Http/Controllers/StudentManagementController.php
+++ b/app/Http/Controllers/StudentManagementController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Course;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+use App\Enums\UserRole;
+use Inertia\Inertia;
+
+class StudentManagementController extends Controller
+{
+    public function index(Request $request)
+    {
+        $auth = $request->user();
+
+        if (! in_array($auth->role, [UserRole::ADMIN, UserRole::AUTHOR])) {
+            abort(403);
+        }
+
+        $coursesQuery = Course::query();
+        if ($auth->role === UserRole::AUTHOR) {
+            $coursesQuery->where('user_id', $auth->id);
+        }
+        $courses = $coursesQuery->get();
+
+        $selectedId = $request->input('course_id');
+        $selectedCourse = null;
+        if ($selectedId) {
+            $selectedCourse = Course::with('students')->find($selectedId);
+        } elseif ($courses->count()) {
+            $selectedCourse = Course::with('students')->find($courses->first()->id);
+            $selectedId = $selectedCourse?->id;
+        }
+
+        $searchEmail = $request->input('email');
+        $searchedCourses = [];
+        if ($searchEmail) {
+            $student = User::where('email', $searchEmail)->first();
+            if ($student) {
+                $scQuery = $student->courses();
+                if ($auth->role === UserRole::AUTHOR) {
+                    $scQuery->where('courses.user_id', $auth->id);
+                }
+                $searchedCourses = $scQuery->with('author')->get();
+            }
+        }
+
+        return Inertia::render('Students/Index', [
+            'courses' => $courses,
+            'selectedCourse' => $selectedCourse,
+            'selectedId' => $selectedId,
+            'searchEmail' => $searchEmail,
+            'searchedCourses' => $searchedCourses,
+        ]);
+    }
+
+    public function store(Request $request, Course $course)
+    {
+        $auth = $request->user();
+
+        if (! ($auth->role === UserRole::ADMIN || $auth->id === $course->user_id)) {
+            abort(403);
+        }
+
+        $data = $request->validate([
+            'identifier' => 'required|string',
+        ]);
+
+        $student = User::where('id', $data['identifier'])
+            ->orWhere('email', $data['identifier'])->firstOrFail();
+
+        $course->students()->syncWithoutDetaching([$student->id]);
+
+        return Redirect::back();
+    }
+}

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -46,6 +46,13 @@ const showingNavigationDropdown = ref(false);
                                 >
                                     My Courses
                                 </NavLink>
+                                <NavLink
+                                    v-if="['admin','author'].includes($page.props.auth.user.role)"
+                                    :href="route('students.index')"
+                                    :active="route().current('students.index')"
+                                >
+                                    Students
+                                </NavLink>
                             </div>
                         </div>
 
@@ -159,6 +166,13 @@ const showingNavigationDropdown = ref(false);
                             :active="route().current('courses.manage')"
                         >
                             My Courses
+                        </ResponsiveNavLink>
+                        <ResponsiveNavLink
+                            v-if="['admin','author'].includes($page.props.auth.user.role)"
+                            :href="route('students.index')"
+                            :active="route().current('students.index')"
+                        >
+                            Students
                         </ResponsiveNavLink>
                     </div>
 

--- a/resources/js/Pages/Students/Index.vue
+++ b/resources/js/Pages/Students/Index.vue
@@ -1,0 +1,89 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import { ref, watch } from 'vue';
+
+const props = defineProps({
+    courses: Array,
+    selectedCourse: Object,
+    selectedId: Number,
+    searchEmail: String,
+    searchedCourses: Array,
+});
+
+const selected = ref(props.selectedId);
+
+watch(selected, (val) => {
+    window.location = route('students.index', { course_id: val });
+});
+
+const form = useForm({
+    identifier: '',
+});
+
+function addStudent() {
+    if (!selected.value) return;
+    form.post(route('students.store', selected.value), {
+        preserveScroll: true,
+        onSuccess: () => form.reset(),
+    });
+}
+</script>
+
+<template>
+    <Head title="Students" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="text-xl font-semibold leading-tight text-gray-800">Students</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+                <div class="mb-6 overflow-hidden bg-white p-6 shadow-sm sm:rounded-lg">
+                    <label class="mr-2">Select Course:</label>
+                    <select v-model="selected" class="rounded border-gray-300">
+                        <option v-for="c in courses" :key="c.id" :value="c.id">{{ c.title }}</option>
+                    </select>
+                </div>
+
+                <div v-if="selectedCourse" class="mb-6 overflow-hidden bg-white p-6 shadow-sm sm:rounded-lg">
+                    <form @submit.prevent="addStudent" class="mb-4 flex space-x-2">
+                        <input v-model="form.identifier" class="rounded border-gray-300" placeholder="ID or Email" />
+                        <button type="submit" class="rounded bg-blue-600 px-3 py-1 text-white">Add</button>
+                    </form>
+                    <table class="w-full table-auto text-left">
+                        <thead>
+                            <tr>
+                                <th class="border px-2 py-1">ID</th>
+                                <th class="border px-2 py-1">Name</th>
+                                <th class="border px-2 py-1">Email</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr v-for="s in selectedCourse.students" :key="s.id">
+                                <td class="border px-2 py-1">{{ s.id }}</td>
+                                <td class="border px-2 py-1">{{ s.name }}</td>
+                                <td class="border px-2 py-1">{{ s.email }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="overflow-hidden bg-white p-6 shadow-sm sm:rounded-lg">
+                    <form method="get" action="" class="mb-4 flex space-x-2">
+                        <input name="email" :value="searchEmail" class="rounded border-gray-300" placeholder="Search email" />
+                        <button type="submit" class="rounded bg-blue-600 px-3 py-1 text-white">Search</button>
+                    </form>
+                    <div v-if="searchedCourses && searchedCourses.length">
+                        <h3 class="mb-2 font-semibold">Courses for {{ searchEmail }}</h3>
+                        <ul class="list-disc pl-5">
+                            <li v-for="c in searchedCourses" :key="c.id">{{ c.title }}</li>
+                        </ul>
+                    </div>
+                    <div v-else-if="searchEmail" class="text-gray-600">No courses found for this email.</div>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\CourseController;
 use App\Http\Controllers\StudentCourseController;
 use App\Http\Controllers\CourseEnrollmentController;
+use App\Http\Controllers\StudentManagementController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -35,6 +36,9 @@ Route::middleware('auth')->group(function () {
         Route::get('/courses/create', [CourseController::class, 'create'])->name('courses.create');
         Route::post('/courses', [CourseController::class, 'store'])->name('courses.store');
         Route::delete('/courses/{course}', [CourseController::class, 'destroy'])->name('courses.destroy');
+
+        Route::get('/students', [StudentManagementController::class, 'index'])->name('students.index');
+        Route::post('/students/{course}', [StudentManagementController::class, 'store'])->name('students.store');
 
         Route::get('/courses/{course}/students', [CourseEnrollmentController::class, 'index'])->name('courses.students.index');
         Route::post('/courses/{course}/students', [CourseEnrollmentController::class, 'store'])->name('courses.students.store');

--- a/tests/Feature/StudentManagementTest.php
+++ b/tests/Feature/StudentManagementTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Course;
+use App\Enums\UserRole;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_author_can_add_student_and_search(): void
+    {
+        $author = User::factory()->create(['role' => UserRole::AUTHOR]);
+        $student = User::factory()->create();
+        $course = Course::factory()->create(['user_id' => $author->id]);
+
+        $response = $this->actingAs($author)->post("/students/{$course->id}", [
+            'identifier' => $student->email,
+        ]);
+        $response->assertRedirect();
+
+        $this->assertDatabaseHas('course_user', [
+            'course_id' => $course->id,
+            'user_id' => $student->id,
+        ]);
+
+        $response = $this->actingAs($author)->get('/students?email=' . $student->email);
+        $response->assertOk();
+        $response->assertSee($course->title);
+    }
+}


### PR DESCRIPTION
## Summary
- add StudentManagementController for viewing and editing course enrollments
- expose `/students` page to authors/admins
- link Students page in navigation
- add Vue page to manage students and search by email
- test adding a student and searching courses

## Testing
- `php artisan test --parallel` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687c768476848328aaa8bce332147e4a